### PR TITLE
public methods to get vorbis comment dumps

### DIFF
--- a/jflac-codec/src/main/java/org/kc7bfi/jflac/metadata/VorbisComment.java
+++ b/jflac-codec/src/main/java/org/kc7bfi/jflac/metadata/VorbisComment.java
@@ -87,4 +87,15 @@ public class VorbisComment extends Metadata {
         return (String [])sbuff.toArray(new String[0]);
         //return null;
     }
+
+    public VorbisString getComment(int index) throws IndexOutOfBoundsException {
+        if ( index < 0 || index > this.numComments-1 )
+            throw new IndexOutOfBoundsException();
+        return this.comments[index];
+    }
+
+    public int getNumComments() {
+        return this.numComments;
+    }  
+
 }


### PR DESCRIPTION
I wrote a small tool back in 2008 based on jflac.

https://github.com/attilabogar/ecdtool

I've resurrected the project and had to make a few changed into jflac in order to get the same functionality from the java flac library to get the ball rolling...