### PR TITLE
WavWriter constructor enables composing arbitrary wav files

### DIFF
--- a/jflac-codec/src/main/java/org/kc7bfi/jflac/util/WavWriter.java
+++ b/jflac-codec/src/main/java/org/kc7bfi/jflac/util/WavWriter.java
@@ -90,6 +90,26 @@ public class WavWriter {
         this.bps = streamInfo.getBitsPerSample();
         this.sampleRate = streamInfo.getSampleRate();
     }
+
+    /**
+     * The constructor.
+     * @param os            The output sream
+     * @param totalSamples  The total samples to be written
+     * @param channels     Number of channels
+     * @param bps           Number of bits per sample
+     * @param sampleRate    Sample rate per second
+     */
+    public WavWriter(OutputStream os,
+           Long totalSamples, Integer channels,
+           Integer bps, Integer sampleRate) {
+        this.os = new DataOutputStream(os);
+        this.osLE = new LittleEndianDataOutput(this.os);
+        this.totalSamples = totalSamples;
+        this.channels = channels;
+        this.bps = bps;
+        this.sampleRate = sampleRate;
+    }
+
     
     /**
      * The constructor.


### PR DESCRIPTION
However this is outside of the scope of flac, code reuseability suggests this
helper constructor will make the WavWrite util class more useful.