### PR TITLE
Add seek function to FLACDecoder

### DIFF
--- a/jflac-codec/src/main/java/org/kc7bfi/jflac/FLACDecoder.java
+++ b/jflac-codec/src/main/java/org/kc7bfi/jflac/FLACDecoder.java
@@ -23,6 +23,7 @@ package org.kc7bfi.jflac;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Vector;
 
 import org.kc7bfi.jflac.frame.BadHeaderException;
@@ -51,6 +52,10 @@ import org.kc7bfi.jflac.util.CRC16;
  * A Java FLAC decoder.
  * @author kc7bfi
  */
+/**
+ * @author alexdw
+ *
+ */
 public class FLACDecoder {
     private static final int FRAME_FOOTER_CRC_LEN = 16; // bits
     private static final byte[] ID3V2_TAG = new byte[] { 'I', 'D', '3' };
@@ -60,7 +65,8 @@ public class FLACDecoder {
     private int outputCapacity = 0;
     private int outputChannels = 0;
     private long samplesDecoded = 0;
-    private StreamInfo streamInfo;
+    private StreamInfo streamInfo = null;
+    private SeekTable seekTable = null;
     private Frame frame = new Frame();
     private byte[] headerWarmup = new byte[2]; // contains the sync code and reserved bits
     //private int state;
@@ -441,6 +447,181 @@ public class FLACDecoder {
         }
     }
     
+    
+    /**
+     * Attempt to seek to the requested (absolute) sample position in the file.
+     * Actually seeks to the frame which contains the requested sample position.
+     * @param samplesAbsolute	The number of samples from start of file to seek past
+     * @return 	The new sample position in the file (from which the next frame will be read)
+     * @throws IOException 
+     */
+    public long seek(long samplesAbsolute) throws IOException
+    {
+        // move back to start of file
+        if (!(inputStream instanceof RandomFileInputStream))
+        	throw new IOException("Not a RandomFileInputStream: " + inputStream.getClass().getName());
+        ((RandomFileInputStream)inputStream).seek(0);
+        bitStream.reset();
+        samplesDecoded = 0;
+        
+        // track seek delta (difference between requested and current position in samples)
+        long seekDelta = samplesAbsolute - samplesDecoded;
+        
+        // (re-)read metadata (including stream info and seek table)     	
+    	readMetadata();
+    	// check for stream info
+        if (streamInfo == null)
+        	throw new IOException("Could not obtain stream info required for seeking");
+    
+    	// validate requested (absolute) sample position
+    	if (samplesAbsolute < 0 || samplesAbsolute > streamInfo.getTotalSamples())
+    		throw new IllegalArgumentException("Invalid sample position for seek");
+    	
+    	// check if seek to start of file (already done above)
+    	if (seekDelta == 0)
+    		return samplesDecoded; // samplesDecoded == 0
+    	
+    	// use max frame size for seeking backwards
+    	long estimatedFrameSize = streamInfo.getMaxFrameSize();    	
+    	
+    	// use data start and end positions as initial lower and upper bounds for seeking 	
+    	// Note: should be at first data frame immediately after readMetadata()
+    	findFrameSync(); // this reads up to the 2 sync bytes of the first data frame into bitStream
+    	// Note: uses virtual temporary SeekPoint variables to store sample/byte offset pairs
+    	int samplePositionUpper = (int) streamInfo.getTotalSamples();
+    	long bytePositionUpper = ((RandomFileInputStream)inputStream).getLength()
+    							 - estimatedFrameSize;
+    	// Note: maximum frame size used to increase chance of being before final frame
+    	//	 	 (though still may not be if file contains ID3 tags after audio data)
+    	SeekPoint beforeSeekPosition = new SeekPoint(0, bitStream.getTotalBytesRead() - 2,
+    												 samplePositionUpper);
+    	SeekPoint afterSeekPosition = new SeekPoint(samplePositionUpper, bytePositionUpper,
+    												streamInfo.getMinBlockSize());
+    	
+    	// TODO use seekTable to (greatly) improve these initial lower and upper bounds
+    	if (!(seekTable == null))
+    	{
+    		
+    	}
+    	
+    	// seek to estimate within upper and lower bounds
+    	double percentBetweenSeekPositions = (samplesAbsolute - beforeSeekPosition.getSampleNumber())
+    										 / (double) (afterSeekPosition.getSampleNumber() 
+    												 	 - beforeSeekPosition.getSampleNumber());
+    	long bytePositionEstimate = beforeSeekPosition.getStreamOffset()
+    								+ (long) ((afterSeekPosition.getStreamOffset()
+    								           - beforeSeekPosition.getStreamOffset())
+    										  * percentBetweenSeekPositions);
+    	((RandomFileInputStream)inputStream).seek(bytePositionEstimate);
+    	bitStream.reset();
+    	
+    	// loop until at requested sample position
+    	// Note: currently will exit loop when current frame contains requested sample position
+    	int framesToSeekBack = 1; // number of frames to go back if past requested position    	
+    	while (!(seekDelta == 0)) // Note: this condition is not currently used
+    	{
+    		// save the current byte position
+    		bytePositionEstimate += bitStream.getTotalBytesRead();
+    		
+        	// get the next data frame from the current position
+    		Frame currentFrame = readNextFrame();
+    		if (currentFrame == null)
+    		{
+    			// no frame read from file (likely no data frames remaining)
+    			if (eof)
+    			{
+    				// end of file: attempt to seek back to previous frame (or further if required)
+    				// TODO bytePositionEstimate and framesToSeekBack need to be byref
+    				bytePositionEstimate = seekBackwards(bytePositionEstimate, framesToSeekBack,
+    													 estimatedFrameSize);
+    			}
+    			else // not end of file (unexpected file error)
+    				throw new IOException("Fatal seek data frame reading error"); 
+    		}
+    		else
+    		{
+    			// frame read from file:
+    			// use header to update current position
+    			samplesDecoded = currentFrame.header.sampleNumber;
+    			
+    			// update seek delta to determine if further iterations required
+    			seekDelta = samplesAbsolute - samplesDecoded;
+    			if (seekDelta < 0)
+    			{
+    				// requested sample is behind current frame:
+    				// seek backwards (firstly by one frame, then further if required)
+    				bytePositionEstimate = seekBackwards(bytePositionEstimate, framesToSeekBack,
+							 							 estimatedFrameSize);
+    			}
+    			else if (seekDelta < currentFrame.header.blockSize) // && seekDelta >= 0
+    			{
+    				// requested sample is in current frame (success):
+    				// reposition pointer to before the frame
+    		        ((RandomFileInputStream)inputStream).seek(bytePositionEstimate);
+    		        bitStream.reset();
+    		        // TODO make this more efficient, currently reads the same frame twice
+    		        // reposition to immediately before the frame 
+    				findFrameSync(); // positions 2 bytes into the frame (as reads the 2 sync bytes)
+    				bytePositionEstimate += bitStream.getTotalBytesRead();
+    				((RandomFileInputStream)inputStream).seek(bytePositionEstimate - 2);
+    				bitStream.reset();
+    				// success: exit loop at current position (immediately before frame)
+    				break;
+    			}
+    			else if (seekDelta >= currentFrame.header.blockSize)
+    			{
+    				// requested sample is ahead of current frame:
+    				framesToSeekBack = 0; // should not need to go backwards now
+    				// iterate again to get the next data frame
+    				continue;
+    			}
+    			else // this should not be possible, as above should cover all cases
+    				throw new IOException("Fatal seek logic error");    			
+    		}
+    	}
+    	
+    	// return current sample position in file
+    	return samplesDecoded;
+    }
+    
+    /** Used by seek() to seek backwards, without causing an infinite loop.
+     * @param bytePositionEstimate	The next position to seek to (in bytes)
+     * @param framesToSeekBack		The number of frames to seek backwards
+     * @param estimatedFrameSize	The size (in bytes) of a frame
+     * @return 	The new position in the file (in bytes)
+     * @throws IOException
+     */
+    private long seekBackwards(long bytePositionEstimate, int framesToSeekBack, long estimatedFrameSize) 
+    		throws IOException 
+    {
+    	if (framesToSeekBack > 0)
+		{
+			// attempt to seek back to previous frame
+			bytePositionEstimate -= framesToSeekBack * estimatedFrameSize;
+			if (bytePositionEstimate < 0)
+			{
+				// prevent seeking before start of file
+				bytePositionEstimate = 0;
+				// should not need to seek backwards again
+				framesToSeekBack = 0;
+			}
+			else
+			{
+				// TODO framesToSeekBack currently not byref so this will have no impact...
+				// seek back by further next time if position past required sample again
+				framesToSeekBack++;
+			}        
+		}
+		else // throw error: was behind (hence framesToSeekBack < 1) and now ahead
+			throw new IOException("Fatal seek error: sample position not found");
+    	
+    	// seek back to new estimated position (should be before previous frame)
+    	((RandomFileInputStream)inputStream).seek(bytePositionEstimate);
+    	bitStream.reset();
+    	
+    	return bytePositionEstimate;
+	}
+    
     /*
      private boolean processUntilEndOfStream() throws IOException {
      //boolean got_a_frame;
@@ -469,8 +650,8 @@ public class FLACDecoder {
        }
        }
        */
-    
-    /**
+
+	/**
      * Read the next data frame.
      * @return  The next frame
      * @throws IOException  on read error
@@ -592,7 +773,9 @@ public class FLACDecoder {
             metadata = streamInfo;
             pcmProcessors.processStreamInfo((StreamInfo)metadata);
         } else if (type == Metadata.METADATA_TYPE_SEEKTABLE) {
-            metadata = new SeekTable(bitStream, length, isLast);
+        	seekTable = new SeekTable(bitStream, length, isLast);
+            metadata = seekTable;
+            // TODO pre-process seekTable here?
         } else if (type == Metadata.METADATA_TYPE_APPLICATION) {
             metadata = new Application(bitStream, length, isLast);
         } else if (type == Metadata.METADATA_TYPE_PADDING) {

--- a/jflac-codec/src/main/java/org/kc7bfi/jflac/io/BitInputStream.java
+++ b/jflac-codec/src/main/java/org/kc7bfi/jflac/io/BitInputStream.java
@@ -120,6 +120,7 @@ public class BitInputStream {
         getBit = 0;
         putByte = 0;
         availBits = 0;
+        totalBitsRead = 0;
     }
     
     /**

--- a/jflac-codec/src/main/java/org/kc7bfi/jflac/io/RandomFileInputStream.java
+++ b/jflac-codec/src/main/java/org/kc7bfi/jflac/io/RandomFileInputStream.java
@@ -138,4 +138,13 @@ public class RandomFileInputStream extends InputStream {
     public void seek(long pos) throws IOException {
         randomFile.seek(pos);
     }
+    
+    /**
+     * Return the length (in bytes) of the file
+     * @return number of bytes length of the file
+     * @throws IOException On file error
+     */
+    public long getLength() throws IOException {
+    	return randomFile.length();
+    }
 }

--- a/jflac-codec/src/main/java/org/kc7bfi/jflac/metadata/StreamInfo.java
+++ b/jflac-codec/src/main/java/org/kc7bfi/jflac/metadata/StreamInfo.java
@@ -158,7 +158,7 @@ public class StreamInfo extends Metadata {
     public String toString() {
         return "StreamInfo:" 
             + " BlockSize=" + minBlockSize + "-" + maxBlockSize
-            + " FrameSize" + minFrameSize + "-" + maxFrameSize
+            + " FrameSize=" + minFrameSize + "-" + maxFrameSize
             + " SampleRate=" + sampleRate
             + " Channels=" + channels
             + " BPS=" + bitsPerSample


### PR DESCRIPTION
Add seek() function to FLACDecoder, to allow repositioning of the file pointer at a given sample position. The current implementation will seek to the frame containing the requested absolute sample offset from the start of the file, using the SeekTable in the FLAC metadata where available.

After calling seek(), the client calls readFrame() / decodeFrame() as normal to retrieve the decoded audio data for the frame which contains the requested sample position.